### PR TITLE
Removed hardcoded SDK path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Mr. Green's Workshop https://www.MrGreensWorkshop.com
 # SPDX-License-Identifier: Apache-2.0
 
-set(PICO_SDK_PATH "/Users/wasdwasd0105/pico/pico-sdk")
+set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
 
 
 # Set minimum CMake version


### PR DESCRIPTION
Replaced the hardcoded SDK path with the standard Pi Pico environment variable.
Tested on Ubuntu 22.04.3 LTS and cmake 3.22.1